### PR TITLE
Fix 500 error caused by content type

### DIFF
--- a/src/wekanapi/__init__.py
+++ b/src/wekanapi/__init__.py
@@ -13,7 +13,7 @@ class WekanApi:
         else:
             api_response = self.session.post(
                 "{}{}".format(self.api_url, url),
-                data=data,
+                json=data,
                 headers={"Authorization": "Bearer {}".format(self.token)} if authed else {},
                 proxies=self.proxies
             )


### PR DESCRIPTION
Fix 500 error caused by content type.

The fix is similar to https://github.com/wekan/wekan/commit/aa2c3774a233025a163e9d9c210ad2f1807c0acb

Otherwise python api client will not be able to login and will get a 500 error.